### PR TITLE
Fix benchmark warm-start provenance and workspace safety

### DIFF
--- a/benchmarks/build_workspace.py
+++ b/benchmarks/build_workspace.py
@@ -81,12 +81,11 @@ def validate_output_dir(output_dir: Path, *, root: Path, overwrite: bool) -> Pat
             f"Refusing to overwrite unsafe output directory: {resolved_output}"
         )
 
-    # Also refuse overwrite targets nested inside the repo, since removing them
-    # can delete tracked project files or corrupt the checkout.
-    if overwrite and resolved_output.is_relative_to(resolved_root):
-        raise ValueError(
-            f"Refusing to overwrite output directory inside repo: {resolved_output}"
-        )
+    # Always refuse output targets nested inside the repo. Even without
+    # --overwrite, building into a descendant of the source tree can recurse
+    # into copied content or leave benchmark artifacts mixed into the checkout.
+    if resolved_output.is_relative_to(resolved_root) and resolved_output != resolved_root:
+        raise ValueError(f"Refusing to build output directory inside repo: {resolved_output}")
 
     # Also reject obvious filesystem roots like '/'.
     if overwrite and resolved_output == resolved_output.parent:

--- a/bo_workflow/engine.py
+++ b/bo_workflow/engine.py
@@ -385,13 +385,38 @@ class BOEngine:
             },
         }
 
-        phase_indices = [
-            idx
-            for idx, row in enumerate(observations)
-            if row.get("suggestion_id") is not None
-        ]
+        seed_count = min(max(int(state.get("seed_observations_count", 0)), 0), total)
+        if seed_count > 0:
+            seed_values = y_values[:seed_count]
+            if objective == "min":
+                seed_best_idx = int(np.argmin(seed_values))
+                seed_best_value = float(np.min(seed_values))
+            else:
+                seed_best_idx = int(np.argmax(seed_values))
+                seed_best_value = float(np.max(seed_values))
+            summary["seed_phase"] = {
+                "num_observations": seed_count,
+                "start_observation": 1,
+                "end_observation": seed_count,
+                "min_value": float(np.min(seed_values)),
+                "max_value": float(np.max(seed_values)),
+                "best_value": seed_best_value,
+                "best_observation_number": seed_best_idx + 1,
+            }
+
+        if seed_count > 0:
+            phase_indices = list(range(seed_count, total))
+        else:
+            phase_indices = [
+                idx
+                for idx, row in enumerate(observations)
+                if row.get("suggestion_id") is not None
+            ]
+            if not phase_indices:
+                phase_indices = list(range(total))
+
         if not phase_indices:
-            phase_indices = list(range(total))
+            return summary
 
         phase_engines = {
             str(observations[idx].get("engine", state.get("default_engine", "hebo")))
@@ -400,7 +425,8 @@ class BOEngine:
         if phase_engines == {"random"}:
             random_indices = phase_indices
         else:
-            random_indices = phase_indices[: min(init_random, len(phase_indices))]
+            random_budget_remaining = max(0, init_random - seed_count)
+            random_indices = phase_indices[: min(random_budget_remaining, len(phase_indices))]
         if random_indices:
             random_values = y_values[random_indices]
             if objective == "min":
@@ -441,6 +467,11 @@ class BOEngine:
             if "random_phase" in summary:
                 guided_summary["improvement_over_random_best"] = improve_delta(
                     summary["random_phase"]["best_value"],
+                    guided_best_value,
+                )
+            elif "seed_phase" in summary:
+                guided_summary["improvement_over_seed_best"] = improve_delta(
+                    summary["seed_phase"]["best_value"],
                     guided_best_value,
                 )
             summary["model_guided_phase"] = guided_summary
@@ -554,6 +585,7 @@ class BOEngine:
             "drop_cols": list(drop_cols) if drop_cols else [],
             "ignored_features": [],
             "constraints": [],
+            "seed_observations_count": 0,
         }
         if constraints:
             # Validate and round-trip through constraint objects to catch errors early.
@@ -749,6 +781,7 @@ class BOEngine:
 
         target_col = state["target_column"]
         existing = read_jsonl(self._paths(run_id).observations)
+        existing_suggestions = read_jsonl(self._paths(run_id).suggestions)
         next_iteration = len(existing)
         rows = []
 
@@ -787,6 +820,10 @@ class BOEngine:
             rows.append(payload)
 
         state["updated_at"] = utc_now_iso()
+        if not existing_suggestions:
+            state["seed_observations_count"] = int(
+                state.get("seed_observations_count", 0)
+            ) + len(rows)
         self._save_state(run_id, state)
         self._log(
             verbose,

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -137,13 +137,14 @@ def test_report_trajectory_summary_matches_observations(
     )
     run_id = state["run_id"]
 
+    suggestions = engine.suggest(run_id, batch_size=4)["suggestions"]
     engine.observe(
         run_id,
         [
-            {"x": {"x": 0.1}, "y": 0.42},
-            {"x": {"x": 0.2}, "y": 0.36},
-            {"x": {"x": 0.3}, "y": 0.37},
-            {"x": {"x": 0.4}, "y": 0.355},
+            {"x": {"x": 0.1}, "y": 0.42, "suggestion_id": suggestions[0]["suggestion_id"]},
+            {"x": {"x": 0.2}, "y": 0.36, "suggestion_id": suggestions[1]["suggestion_id"]},
+            {"x": {"x": 0.3}, "y": 0.37, "suggestion_id": suggestions[2]["suggestion_id"]},
+            {"x": {"x": 0.4}, "y": 0.355, "suggestion_id": suggestions[3]["suggestion_id"]},
         ],
         source="benchmark-evaluator",
     )
@@ -201,13 +202,14 @@ def test_report_trajectory_summary_treats_random_engine_as_fully_random(
     )
     run_id = state["run_id"]
 
+    suggestions = engine.suggest(run_id, batch_size=4)["suggestions"]
     engine.observe(
         run_id,
         [
-            {"x": {"x": 0.1}, "y": 0.42},
-            {"x": {"x": 0.2}, "y": 0.36},
-            {"x": {"x": 0.3}, "y": 0.37},
-            {"x": {"x": 0.4}, "y": 0.355},
+            {"x": {"x": 0.1}, "y": 0.42, "suggestion_id": suggestions[0]["suggestion_id"]},
+            {"x": {"x": 0.2}, "y": 0.36, "suggestion_id": suggestions[1]["suggestion_id"]},
+            {"x": {"x": 0.3}, "y": 0.37, "suggestion_id": suggestions[2]["suggestion_id"]},
+            {"x": {"x": 0.4}, "y": 0.355, "suggestion_id": suggestions[3]["suggestion_id"]},
         ],
         source="benchmark-evaluator",
     )
@@ -227,7 +229,7 @@ def test_report_trajectory_summary_treats_random_engine_as_fully_random(
     assert "model_guided_phase" not in trajectory
 
 
-def test_report_trajectory_summary_excludes_seeded_observations_from_phase_split(
+def test_report_trajectory_summary_treats_pre_suggest_observations_as_seed_phase(
     tmp_path: Path,
 ) -> None:
     runs_root = tmp_path / "bo_runs"
@@ -246,7 +248,8 @@ def test_report_trajectory_summary_excludes_seeded_observations_from_phase_split
     )
     run_id = state["run_id"]
 
-    # Seeded observations should not be treated as the BO random phase.
+    # Pre-suggest observations are warm-start seed data and should be summarized
+    # separately from the BO-controlled phase split.
     engine.observe(
         run_id,
         [
@@ -255,13 +258,18 @@ def test_report_trajectory_summary_excludes_seeded_observations_from_phase_split
         ],
         source="pool-seed",
     )
+
+    # Later BO observations may be recorded without suggestion_id in manual
+    # suggest/observe flows; they should still be treated as BO-phase rows once
+    # suggestions exist.
+    engine.suggest(run_id, batch_size=4)
     engine.observe(
         run_id,
         [
-            {"x": {"x": 0.10}, "y": 0.42, "suggestion_id": "s1", "engine": "hebo"},
-            {"x": {"x": 0.20}, "y": 0.36, "suggestion_id": "s2", "engine": "hebo"},
-            {"x": {"x": 0.30}, "y": 0.37, "suggestion_id": "s3", "engine": "hebo"},
-            {"x": {"x": 0.40}, "y": 0.355, "suggestion_id": "s4", "engine": "hebo"},
+            {"x": {"x": 0.10}, "y": 0.42, "engine": "hebo"},
+            {"x": {"x": 0.20}, "y": 0.36, "engine": "hebo"},
+            {"x": {"x": 0.30}, "y": 0.37, "engine": "hebo"},
+            {"x": {"x": 0.40}, "y": 0.355, "engine": "hebo"},
         ],
         source="benchmark-evaluator",
     )
@@ -269,21 +277,22 @@ def test_report_trajectory_summary_excludes_seeded_observations_from_phase_split
     report = engine.report(run_id)
     trajectory = report["trajectory"]
 
-    assert trajectory["random_phase"] == {
+    assert trajectory["seed_phase"] == {
         "num_observations": 2,
-        "start_observation": 3,
-        "end_observation": 4,
-        "min_value": 0.36,
-        "max_value": 0.42,
-        "best_value": 0.36,
-        "best_observation_number": 4,
+        "start_observation": 1,
+        "end_observation": 2,
+        "min_value": 0.49,
+        "max_value": 0.5,
+        "best_value": 0.49,
+        "best_observation_number": 2,
     }
-    assert trajectory["model_guided_phase"]["num_observations"] == 2
-    assert trajectory["model_guided_phase"]["start_observation"] == 5
+    assert "random_phase" not in trajectory
+    assert trajectory["model_guided_phase"]["num_observations"] == 4
+    assert trajectory["model_guided_phase"]["start_observation"] == 3
     assert trajectory["model_guided_phase"]["end_observation"] == 6
     assert trajectory["model_guided_phase"]["best_observation_number"] == 6
-    assert trajectory["model_guided_phase"]["improvement_over_random_best"] == pytest.approx(
-        0.005
+    assert trajectory["model_guided_phase"]["improvement_over_seed_best"] == pytest.approx(
+        0.135
     )
 
 
@@ -306,6 +315,13 @@ def test_build_workspace_rejects_overwriting_repo_or_ancestor(
             output_dir=fake_root / "nested-output",
             task_ids=["oer"],
             overwrite=True,
+        )
+
+    with pytest.raises(ValueError, match="inside repo"):
+        build_workspace(
+            output_dir=fake_root / "nested-output-no-overwrite",
+            task_ids=["oer"],
+            overwrite=False,
         )
 
 


### PR DESCRIPTION
## Summary
- reject benchmark workspace output directories nested inside the repo, even without `--overwrite`
- track warm-start seed observations explicitly in BO state and report them as a separate trajectory phase
- avoid misclassifying later manual suggest/observe rows as BO random-phase observations when `suggestion_id` is absent
- update benchmark tests to cover both safety and warm-start provenance behavior

## Why
This is a small follow-up to the benchmark harness PR. Two review comments were still worth addressing before future tasks like EGFR warm-start are added:
- building a public workspace into a descendant of the source repo is a footgun even on first build
- trajectory summaries needed explicit seed provenance so warm-start/manual flows stay interpretable

## Validation
- `uv run pytest tests/test_benchmarks.py`
- `git diff --check`

Follow-up to #20.