### PR TITLE
Support deferred imports in local python evaluators

### DIFF
--- a/bo_workflow/evaluation/python_module.py
+++ b/bo_workflow/evaluation/python_module.py
@@ -19,15 +19,16 @@ from ..utils import read_jsonl, utc_now_iso
 @contextmanager
 def _module_parent_on_sys_path(module_path: Path):
     parent = str(module_path.parent)
-    added_path = False
+    inserted_index: int | None = None
     if parent not in sys.path:
         sys.path.insert(0, parent)
-        added_path = True
+        inserted_index = 0
     try:
         yield
     finally:
-        if added_path and parent in sys.path:
-            sys.path.remove(parent)
+        if inserted_index is not None and len(sys.path) > inserted_index:
+            if sys.path[inserted_index] == parent:
+                sys.path.pop(inserted_index)
 
 
 def _validate_python_evaluator_preconditions(

--- a/bo_workflow/evaluation/python_module.py
+++ b/bo_workflow/evaluation/python_module.py
@@ -5,6 +5,7 @@ backend-id flow via a persisted `backend_kind="python_module"` backend shape so
 `run-evaluator --backend-id ...` becomes the normalized evaluator entrypoint.
 """
 
+from contextlib import contextmanager
 import importlib.util
 from pathlib import Path
 import sys
@@ -13,6 +14,20 @@ from typing import Any
 from ..engine import BOEngine
 from ..observers.callback import CallbackObserver
 from ..utils import read_jsonl, utc_now_iso
+
+
+@contextmanager
+def _module_parent_on_sys_path(module_path: Path):
+    parent = str(module_path.parent)
+    added_path = False
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+        added_path = True
+    try:
+        yield
+    finally:
+        if added_path and parent in sys.path:
+            sys.path.remove(parent)
 
 
 def _validate_python_evaluator_preconditions(
@@ -70,16 +85,8 @@ def _load_python_evaluator(module_path: str | Path, function_name: str) -> Any:
         raise ImportError(f"Could not load Python evaluator module: {module_path}")
 
     module = importlib.util.module_from_spec(spec)
-    added_path = False
-    parent = str(module_path.parent)
-    if parent not in sys.path:
-        sys.path.insert(0, parent)
-        added_path = True
-    try:
+    with _module_parent_on_sys_path(module_path):
         spec.loader.exec_module(module)
-    finally:
-        if added_path and sys.path and sys.path[0] == parent:
-            sys.path.pop(0)
 
     fn = getattr(module, function_name, None)
     if fn is None or not callable(fn):
@@ -176,16 +183,17 @@ def run_python_module_evaluator(
 
     def callback(suggestions: list[dict[str, Any]]) -> list[dict[str, Any]]:
         observations = []
-        for suggestion in suggestions:
-            result = evaluator(dict(suggestion["x"]))
-            observations.append(
-                _normalize_python_evaluator_result(
-                    result=result,
-                    suggestion=suggestion,
-                    target_column=target_column,
-                    default_engine=default_engine,
+        with _module_parent_on_sys_path(module_path):
+            for suggestion in suggestions:
+                result = evaluator(dict(suggestion["x"]))
+                observations.append(
+                    _normalize_python_evaluator_result(
+                        result=result,
+                        suggestion=suggestion,
+                        target_column=target_column,
+                        default_engine=default_engine,
+                    )
                 )
-            )
         return observations
 
     class PythonEvaluatorObserver(CallbackObserver):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+import sys
 
 import numpy as np
 import pandas as pd
@@ -483,6 +484,74 @@ def test_run_python_evaluator_supports_deferred_sibling_helper_imports(
     )
 
     assert payload["recorded"] == 1
+
+
+def test_run_python_evaluator_does_not_leak_sys_path_when_evaluator_reinserts_parent(
+    tmp_path: Path,
+) -> None:
+    helper_path = tmp_path / "helper.py"
+    helper_path.write_text(
+        "\n".join(
+            [
+                "def objective(x):",
+                "    return 1.0 - abs(x - 0.3)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    module_path = tmp_path / "blackbox_her.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                "import sys",
+                "",
+                "def evaluate(composition):",
+                "    parent = str(Path(__file__).resolve().parent)",
+                "    sys.path.insert(0, parent)",
+                "    from helper import objective",
+                "",
+                "    x = float(composition['x'])",
+                "    return {'y': objective(x)}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runs_root = tmp_path / "bo_runs"
+    engine = BOEngine(runs_root=runs_root)
+    state = engine.init_run(
+        target_column="exchange_current_density",
+        objective="max",
+        search_space_spec={
+            "design_parameters": [
+                {"name": "x", "type": "num", "lb": 0.0, "ub": 1.0}
+            ],
+            "fixed_features": {},
+        },
+        seed=42,
+        num_initial_random_samples=2,
+    )
+
+    parent = str(tmp_path.resolve())
+    before = sys.path.count(parent)
+
+    payload = run_python_module_evaluator(
+        engine,
+        run_id=state["run_id"],
+        module_path=module_path,
+        num_iterations=1,
+        batch_size=1,
+    )
+
+    after = sys.path.count(parent)
+    assert payload["recorded"] == 1
+    assert after == before + 1
+
+    while sys.path.count(parent) > before:
+        sys.path.remove(parent)
 
 
 def test_report_trajectory_summary_matches_observations(

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -430,6 +430,61 @@ def test_run_python_evaluator_supports_sibling_helper_imports(
     assert payload["recorded"] == 1
 
 
+def test_run_python_evaluator_supports_deferred_sibling_helper_imports(
+    tmp_path: Path,
+) -> None:
+    helper_path = tmp_path / "helper.py"
+    helper_path.write_text(
+        "\n".join(
+            [
+                "def objective(x):",
+                "    return 1.0 - abs(x - 0.3)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    module_path = tmp_path / "blackbox_her.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "def evaluate(composition):",
+                "    from helper import objective",
+                "",
+                "    x = float(composition['x'])",
+                "    return {'y': objective(x)}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runs_root = tmp_path / "bo_runs"
+    engine = BOEngine(runs_root=runs_root)
+    state = engine.init_run(
+        target_column="exchange_current_density",
+        objective="max",
+        search_space_spec={
+            "design_parameters": [
+                {"name": "x", "type": "num", "lb": 0.0, "ub": 1.0}
+            ],
+            "fixed_features": {},
+        },
+        seed=42,
+        num_initial_random_samples=2,
+    )
+
+    payload = run_python_module_evaluator(
+        engine,
+        run_id=state["run_id"],
+        module_path=module_path,
+        num_iterations=1,
+        batch_size=1,
+    )
+
+    assert payload["recorded"] == 1
+
+
 def test_report_trajectory_summary_matches_observations(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

This follow-up PR addresses one more real edge case in the local Python evaluator path.

`run-python-evaluator` now keeps the evaluator module directory importable not just during module load, but also during callback execution, so deferred sibling imports inside `evaluate()` work reliably.

## Changes

- keep the evaluator module parent on `sys.path` while loading the module and while invoking the evaluator callback
- add a regression test for deferred sibling imports inside `evaluate()`
- retain the focused benchmark test coverage around the local python evaluator path

## Validation

- `git diff --check` passed
- `uv run pytest -q tests/test_benchmarks.py` passed (`16 passed`)

## Why this matters

This fixes a real workflow bug for multi-file local evaluators under `research_runs/.../scripts/`, where top-level sibling imports worked but deferred imports inside `evaluate()` could fail at runtime with `ModuleNotFoundError`.